### PR TITLE
fixes issue with using singularity on Orion

### DIFF
--- a/module_check.sh
+++ b/module_check.sh
@@ -10,7 +10,7 @@ elif [[ ${HOSTNAME} == *"hfe"* ]]; then
 fi
 
 # check which modules are required and notify the user if they are not currently loaded in the environment.
-if [[ ${MACHINE} == "orion" || ${MACHINE} == "hera" && ${USE_SINGULARITY} != "yes" ]]; then 
+if [[ ( ${MACHINE} == "orion" || ${MACHINE} == "hera" ) && ${USE_SINGULARITY} != "yes" ]]; then 
   env_mods=($(grep -o 'load("[^"]*")' ${CYCLEDIR}/modulefiles/landda_${MACHINE}.intel.lua | sed 's/load("//;s/")//'))
 
   missing_mods=()


### PR DESCRIPTION
This fixes an issue with the module_check.sh script that I found on Orion last night. There were missing parens in the if statement testing for running on Orion or Hera but not using singularity.
